### PR TITLE
Switch order to provide properly magic-number-based mime to callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,20 +39,23 @@ function autoContentType (req, file, cb) {
 }
 
 function collect (storage, req, file, cb) {
-  parallel([
-    storage.getBucket.bind(storage, req, file),
-    storage.getKey.bind(storage, req, file),
-    storage.getAcl.bind(storage, req, file),
-    storage.getMetadata.bind(storage, req, file),
-    storage.getCacheControl.bind(storage, req, file),
-    storage.getContentDisposition.bind(storage, req, file),
-    storage.getStorageClass.bind(storage, req, file),
-    storage.getSSE.bind(storage, req, file),
-    storage.getSSEKMS.bind(storage, req, file)
-  ], function (err, values) {
+
+  storage.getContentType(req, file, function (err, contentType, replacementStream) {
     if (err) return cb(err)
 
-    storage.getContentType(req, file, function (err, contentType, replacementStream) {
+
+    file.calculatedMime = contentType;
+    parallel([
+      storage.getBucket.bind(storage, req, file),
+      storage.getKey.bind(storage, req, file),
+      storage.getAcl.bind(storage, req, file),
+      storage.getMetadata.bind(storage, req, file),
+      storage.getCacheControl.bind(storage, req, file),
+      storage.getContentDisposition.bind(storage, req, file),
+      storage.getStorageClass.bind(storage, req, file),
+      storage.getSSE.bind(storage, req, file),
+      storage.getSSEKMS.bind(storage, req, file)
+    ], function (err, values) {
       if (err) return cb(err)
 
       cb.call(storage, null, {
@@ -67,9 +70,43 @@ function collect (storage, req, file, cb) {
         replacementStream: replacementStream,
         serverSideEncryption: values[7],
         sseKmsKeyId: values[8]
-      })
-    })
-  })
+      });
+
+    });
+  });
+
+  // parallel([
+  //   storage.getBucket.bind(storage, req, file),
+  //   storage.getKey.bind(storage, req, file),
+  //   storage.getAcl.bind(storage, req, file),
+  //   storage.getMetadata.bind(storage, req, file),
+  //   storage.getCacheControl.bind(storage, req, file),
+  //   storage.getContentDisposition.bind(storage, req, file),
+  //   storage.getStorageClass.bind(storage, req, file),
+  //   storage.getSSE.bind(storage, req, file),
+  //   storage.getSSEKMS.bind(storage, req, file)
+  // ], function (err, values) {
+  //   if (err) return cb(err)
+
+  //   storage.getContentType(req, file, function (err, contentType, replacementStream) {
+  //     if (err) return cb(err)
+
+  //     cb.call(storage, null, {
+  //       bucket: values[0],
+  //       key: values[1],
+  //       acl: values[2],
+  //       metadata: values[3],
+  //       cacheControl: values[4],
+  //       contentDisposition: values[5],
+  //       storageClass: values[6],
+  //       contentType: contentType,
+  //       replacementStream: replacementStream,
+  //       serverSideEncryption: values[7],
+  //       sseKmsKeyId: values[8]
+  //     })
+  //   })
+
+  // })
 }
 
 function S3Storage (opts) {

--- a/index.js
+++ b/index.js
@@ -71,7 +71,6 @@ function collect (storage, req, file, cb) {
         serverSideEncryption: values[7],
         sseKmsKeyId: values[8]
       });
-
     });
   });
 }

--- a/index.js
+++ b/index.js
@@ -39,12 +39,10 @@ function autoContentType (req, file, cb) {
 }
 
 function collect (storage, req, file, cb) {
-
   storage.getContentType(req, file, function (err, contentType, replacementStream) {
     if (err) return cb(err)
 
-
-    file.calculatedMime = contentType;
+    file.calculatedMime = contentType
     parallel([
       storage.getBucket.bind(storage, req, file),
       storage.getKey.bind(storage, req, file),
@@ -70,9 +68,9 @@ function collect (storage, req, file, cb) {
         replacementStream: replacementStream,
         serverSideEncryption: values[7],
         sseKmsKeyId: values[8]
-      });
-    });
-  });
+      })
+    })
+  })
 }
 
 function S3Storage (opts) {

--- a/index.js
+++ b/index.js
@@ -74,39 +74,6 @@ function collect (storage, req, file, cb) {
 
     });
   });
-
-  // parallel([
-  //   storage.getBucket.bind(storage, req, file),
-  //   storage.getKey.bind(storage, req, file),
-  //   storage.getAcl.bind(storage, req, file),
-  //   storage.getMetadata.bind(storage, req, file),
-  //   storage.getCacheControl.bind(storage, req, file),
-  //   storage.getContentDisposition.bind(storage, req, file),
-  //   storage.getStorageClass.bind(storage, req, file),
-  //   storage.getSSE.bind(storage, req, file),
-  //   storage.getSSEKMS.bind(storage, req, file)
-  // ], function (err, values) {
-  //   if (err) return cb(err)
-
-  //   storage.getContentType(req, file, function (err, contentType, replacementStream) {
-  //     if (err) return cb(err)
-
-  //     cb.call(storage, null, {
-  //       bucket: values[0],
-  //       key: values[1],
-  //       acl: values[2],
-  //       metadata: values[3],
-  //       cacheControl: values[4],
-  //       contentDisposition: values[5],
-  //       storageClass: values[6],
-  //       contentType: contentType,
-  //       replacementStream: replacementStream,
-  //       serverSideEncryption: values[7],
-  //       sseKmsKeyId: values[8]
-  //     })
-  //   })
-
-  // })
 }
 
 function S3Storage (opts) {


### PR DESCRIPTION
I found myself not wanting to rely on reported mime for calculating buckets and meta-data, but instead using the proper mime as determined by the magic number. Since that's already done anyway, switching the order of the independent ops makes it doable. 