### PR TITLE
Support sharp transformations with a new option - transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+.idea/

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "file-type": "^3.3.0",
     "is-svg": "^2.1.0",
-    "run-parallel": "^1.1.6"
+    "run-parallel": "^1.1.6",
+    "sharp": "^0.21.3"
   },
   "devDependencies": {
     "aws-sdk": "^2.2.32",


### PR DESCRIPTION
Added sharp transformer as a new option to allow image transformation.
Passes all tests including a new test with that option. 

Example:
```
const transformer = sharp().resize({ width: 100 });
var storage = multerS3({ s3: s3, bucket: 'test', transformer: transformer }) 
```