### PR TITLE
Update README to Correct Backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Streaming multer storage engine for AWS S3.
 
-This project is mostly an integration piece for existing code samples from Multer's [storage engine documentation](https://github.com/expressjs/multer/blob/master/StorageEngine.md) with [s3fs](https://github.com/RiptideElements/s3fs) as the substitution piece for file system.  Existing solutions I found required buffering the multipart uploads into the actual filesystem which is difficult to scale.
+This project is mostly an integration piece for existing code samples from Multer's [storage engine documentation](https://github.com/expressjs/multer/blob/master/StorageEngine.md) with a call to `s3.upload` (see the [aws-sdk docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property)) as the substitution piece for file system.  Existing solutions I found required buffering the multipart uploads into the actual filesystem which is difficult to scale.
 
 ## Installation
 


### PR DESCRIPTION
#8 changed the back end to use the aws-sdk instead of s3fs (whose [repo link](https://github.com/RiptideElements/s3fs) is now 404ing).

See also #3.

This updates the README to clarify.

Thanks.