### PR TITLE
Fix _handleFile and _removeFile crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var fileType = require('file-type')
 var htmlCommentRegex = require('html-comment-regex')
 var parallel = require('run-parallel')
 var Upload = require('@aws-sdk/lib-storage').Upload
-var DeleteObjectCommand = require('@aws-sdk/client-s3').DeleteObjectCommand;
+var DeleteObjectCommand = require('@aws-sdk/client-s3').DeleteObjectCommand
 var util = require('util')
 
 function staticValue (value) {
@@ -245,9 +245,9 @@ S3Storage.prototype._removeFile = function (req, file, cb) {
   this.s3.send(
     new DeleteObjectCommand({
       Bucket: file.bucket,
-      Key: file.key,
+      Key: file.key
     }),
-    cb,
+    cb
   )
 }
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var fileType = require('file-type')
 var htmlCommentRegex = require('html-comment-regex')
 var parallel = require('run-parallel')
 var Upload = require('@aws-sdk/lib-storage').Upload
+var DeleteObjectCommand = require('@aws-sdk/client-s3').DeleteObjectCommand;
 var util = require('util')
 
 function staticValue (value) {
@@ -241,7 +242,13 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
 }
 
 S3Storage.prototype._removeFile = function (req, file, cb) {
-  this.s3.deleteObject({ Bucket: file.bucket, Key: file.key }, cb)
+  this.s3.send(
+    new DeleteObjectCommand({
+      Bucket: file.bucket,
+      Key: file.key,
+    }),
+    cb,
+  )
 }
 
 module.exports = function (opts) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function staticValue (value) {
 var defaultAcl = staticValue('private')
 var defaultContentType = staticValue('application/octet-stream')
 
-var defaultMetadata = staticValue(null)
+var defaultMetadata = staticValue(undefined)
 var defaultCacheControl = staticValue(null)
 var defaultContentDisposition = staticValue(null)
 var defaultContentEncoding = staticValue(null)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "html-comment-regex": "^1.1.2",
     "run-parallel": "^1.1.6"
   },
+  "peerDependencies": {
+    "@aws-sdk/client-s3": "^3.0.0"
+  },
   "devDependencies": {
     "express": "^4.13.1",
     "form-data": "^1.0.0-rc3",


### PR DESCRIPTION
Fixes _handleFile function crash caused by defaultMetadata value not being correctly aligned with the current AWS SDK S3 API checks. 
Fixes _removeFile function crash caused by using the now removed deleteObject function.

Closes #170 and #171 